### PR TITLE
Docker image build script

### DIFF
--- a/.docker/config.json
+++ b/.docker/config.json
@@ -1,0 +1,5 @@
+{
+    "features": {
+        "buildkit": true
+    }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+.cpm/
+build/
+out/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
 .git/
+.github/
 .cpm/
 build/
 out/
+doc/
+example/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,14 @@ COPY --from=build ${WORKDIR}/out/build/debug-demo/bin ${WORKDIR}/out/build/debug
 
 RUN mkdir -p ${PLUGINSDIR}/lib/ac-local
 
-# COPY --from=build ${PLUGINSDIR}/ilib-llama.cpp-0.1.1-default/bin ${PLUGINSDIR}/ilib-llama.cpp-0.1.1-default/bin
-# RUN cp ${PLUGINSDIR}/ilib-llama.cpp-0.1.1-default/bin/aclp-llama.so ${PLUGINSDIR}/lib/ac-local/aclp-llama.so
+COPY --from=build ${PLUGINSDIR}/ilib-llama.cpp-0.1.1-default/bin ${PLUGINSDIR}/ilib-llama.cpp-0.1.1-default/bin
+RUN cp ${PLUGINSDIR}/ilib-llama.cpp-0.1.1-default/bin/aclp-llama.so ${PLUGINSDIR}/lib/ac-local/aclp-llama.so
 
-# COPY --from=build ${PLUGINSDIR}//ilib-sd.cpp-0.1.1-default/bin ${PLUGINSDIR}//ilib-sd.cpp-0.1.1-default/bin
-# RUN cp ${PLUGINSDIR}/ilib-sd.cpp-0.1.1-default/bin/aclp-sd.so ${PLUGINSDIR}/lib/ac-local/aclp-sd.so && \
+COPY --from=build ${PLUGINSDIR}//ilib-sd.cpp-0.1.1-default/bin ${PLUGINSDIR}//ilib-sd.cpp-0.1.1-default/bin
+RUN cp ${PLUGINSDIR}/ilib-sd.cpp-0.1.1-default/bin/aclp-sd.so ${PLUGINSDIR}/lib/ac-local/aclp-sd.so
 
 COPY --from=build ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin
 RUN cp ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin/aclp-foo.so ${PLUGINSDIR}/lib/ac-local/aclp-foo.so
-
 
 EXPOSE 7654
 CMD ["./out/build/debug-demo/bin/acord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG CMAKEVERSION=3.31.2
 ARG BUILD_TYPE=debug
 
-FROM ubuntu:latest AS base
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04 AS base
 WORKDIR /usr/local/acord
 
 FROM base AS build

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ COPY --from=build ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin ${PLUGINSDIR}/ilib-fo
 RUN cp ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin/aclp-foo.so ${PLUGINSDIR}/lib/ac-local/aclp-foo.so
 
 EXPOSE 7654
-CMD ["./out/build/debug-demo/bin/acord"]
+CMD ["./out/build/debug-demo/bin/acord", "--all"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+ARG CMAKEVERSION=3.31.2
+ARG BUILD_TYPE=debug
+
+FROM ubuntu:latest AS base
+WORKDIR /usr/local/acord
+
+FROM base AS build
+ARG BUILD_TYPE
+
+RUN apt-get update && \
+    apt-get install -y build-essential cmake ninja-build git
+
+COPY . .
+RUN mkdir -p out/build &&\
+    cd out/build && \
+    cmake --preset ${BUILD_TYPE}-demo -G Ninja ../.. && \
+    ninja -C ${BUILD_TYPE}-demo
+
+FROM base AS final
+ARG WORKDIR=/usr/local/acord
+
+# Copy the full directory structure in order to find the plugins
+# TODO: Check how to use rpath instead of copy the full directory structure
+COPY --from=build ${WORKDIR}/out/build/debug-demo/bin ${WORKDIR}/out/build/debug-demo/bin
+COPY --from=build ${WORKDIR}/out/build/debug-demo/_ac-plugins/lib/ac-local ${WORKDIR}/out/build/debug-demo/_ac-plugins/lib/ac-local
+
+EXPOSE 7654
+CMD ["./out/build/debug-demo/bin/acord"]
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,20 +11,31 @@ RUN apt-get update && \
     apt-get install -y build-essential cmake ninja-build git
 
 COPY . .
-RUN mkdir -p out/build &&\
-    cd out/build && \
-    cmake --preset ${BUILD_TYPE}-demo -G Ninja ../.. && \
-    ninja -C ${BUILD_TYPE}-demo
+RUN cmake --preset ${BUILD_TYPE}-demo -G Ninja && \
+    ninja -C out/build/${BUILD_TYPE}-demo
 
 FROM base AS final
 ARG WORKDIR=/usr/local/acord
+ARG PLUGINSDIR=${WORKDIR}/out/build/debug-demo/_ac-plugins
+
+RUN apt-get update && \
+    apt-get install -y build-essential
 
 # Copy the full directory structure in order to find the plugins
 # TODO: Check how to use rpath instead of copy the full directory structure
 COPY --from=build ${WORKDIR}/out/build/debug-demo/bin ${WORKDIR}/out/build/debug-demo/bin
-COPY --from=build ${WORKDIR}/out/build/debug-demo/_ac-plugins/lib/ac-local ${WORKDIR}/out/build/debug-demo/_ac-plugins/lib/ac-local
+
+RUN mkdir -p ${PLUGINSDIR}/lib/ac-local
+
+# COPY --from=build ${PLUGINSDIR}/ilib-llama.cpp-0.1.1-default/bin ${PLUGINSDIR}/ilib-llama.cpp-0.1.1-default/bin
+# RUN cp ${PLUGINSDIR}/ilib-llama.cpp-0.1.1-default/bin/aclp-llama.so ${PLUGINSDIR}/lib/ac-local/aclp-llama.so
+
+# COPY --from=build ${PLUGINSDIR}//ilib-sd.cpp-0.1.1-default/bin ${PLUGINSDIR}//ilib-sd.cpp-0.1.1-default/bin
+# RUN cp ${PLUGINSDIR}/ilib-sd.cpp-0.1.1-default/bin/aclp-sd.so ${PLUGINSDIR}/lib/ac-local/aclp-sd.so && \
+
+COPY --from=build ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin
+RUN cp ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin/aclp-foo.so ${PLUGINSDIR}/lib/ac-local/aclp-foo.so
+
 
 EXPOSE 7654
 CMD ["./out/build/debug-demo/bin/acord"]
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,18 +12,25 @@ RUN apt-get update && \
     apt-get install -y build-essential cmake ninja-build git
 
 COPY . .
-RUN cmake --preset ${BUILD_TYPE}-demo -G Ninja && \
+RUN cmake --preset ${BUILD_TYPE}-demo -DACORD_BUILD_TESTS=OFF -DACORD_BUILD_EXAMPLES=OFF -G Ninja && \
     ninja -C out/build/${BUILD_TYPE}-demo
+
+# RUN cmake --install out/build/${BUILD_TYPE}-demo --prefix /usr/local/acord/install
+
 
 FROM base AS final
 ARG BUILD_TYPE
+ENV BUILD_TYPE=${BUILD_TYPE}
 ENV PLUGINSDIR=${WORKDIR}/out/build/${BUILD_TYPE}-demo/_ac-plugins
 
 RUN apt-get update && \
     apt-get install -y build-essential
 
+
 # Copy the full directory structure in order to find the plugins
 # TODO: Check how to use rpath instead of copy the full directory structure
+# COPY --from=build /usr/local/acord/install/ /usr/local/acord/
+
 COPY --from=build ${WORKDIR}/out/build/${BUILD_TYPE}-demo/bin ${WORKDIR}/out/build/${BUILD_TYPE}-demo/bin
 
 RUN mkdir -p ${PLUGINSDIR}/lib/ac-local
@@ -31,11 +38,11 @@ RUN mkdir -p ${PLUGINSDIR}/lib/ac-local
 COPY --from=build ${PLUGINSDIR}/ilib-llama.cpp-0.1.1-default/bin ${PLUGINSDIR}/ilib-llama.cpp-0.1.1-default/bin
 RUN cp ${PLUGINSDIR}/ilib-llama.cpp-0.1.1-default/bin/aclp-llama.so ${PLUGINSDIR}/lib/ac-local/aclp-llama.so
 
-COPY --from=build ${PLUGINSDIR}//ilib-sd.cpp-0.1.1-default/bin ${PLUGINSDIR}//ilib-sd.cpp-0.1.1-default/bin
+COPY --from=build ${PLUGINSDIR}/ilib-sd.cpp-0.1.1-default/bin ${PLUGINSDIR}//ilib-sd.cpp-0.1.1-default/bin
 RUN cp ${PLUGINSDIR}/ilib-sd.cpp-0.1.1-default/bin/aclp-sd.so ${PLUGINSDIR}/lib/ac-local/aclp-sd.so
 
 COPY --from=build ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin
 RUN cp ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin/aclp-foo.so ${PLUGINSDIR}/lib/ac-local/aclp-foo.so
 
 EXPOSE 7654
-CMD ["./out/build/${BUILD_TYPE}-demo/bin/acord", "--public"]
+CMD ./out/build/${BUILD_TYPE}-demo/bin/acord --public

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,32 @@
 ARG CMAKEVERSION=3.31.2
 ARG BUILD_TYPE=release
 
-FROM nvidia/cuda:12.8.1-devel-ubuntu24.04 AS base
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04 AS dependencies
 ENV WORKDIR=/usr/local/acord
 WORKDIR ${WORKDIR}
-
-FROM base AS build
 ARG BUILD_TYPE
 
 RUN apt-get update && \
-    apt-get install -y build-essential cmake ninja-build git
+    apt-get install -y --no-install-recommends build-essential cmake ninja-build git && \
+    rm -rf /var/lib/apt/lists/*
 
+
+FROM dependencies AS build
 COPY . .
 RUN cmake --preset ${BUILD_TYPE}-demo -DACORD_BUILD_TESTS=OFF -DACORD_BUILD_EXAMPLES=OFF -G Ninja && \
     ninja -C out/build/${BUILD_TYPE}-demo
 
-# RUN cmake --install out/build/${BUILD_TYPE}-demo --prefix /usr/local/acord/install
 
-
-FROM base AS final
+FROM nvidia/cuda:12.8.1-runtime-ubuntu24.04 AS final
+ENV WORKDIR=/usr/local/acord
+WORKDIR ${WORKDIR}
 ARG BUILD_TYPE
 ENV BUILD_TYPE=${BUILD_TYPE}
 ENV PLUGINSDIR=${WORKDIR}/out/build/${BUILD_TYPE}-demo/_ac-plugins
 
 RUN apt-get update && \
-    apt-get install -y build-essential
+    apt-get install -y --no-install-recommends build-essential && \
+    rm -rf /var/lib/apt/lists/*
 
 
 # Copy the full directory structure in order to find the plugins
@@ -45,4 +47,4 @@ COPY --from=build ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin ${PLUGINSDIR}/ilib-fo
 RUN cp ${PLUGINSDIR}/ilib-foo-0.1.3-default/bin/aclp-foo.so ${PLUGINSDIR}/lib/ac-local/aclp-foo.so
 
 EXPOSE 7654
-CMD ./out/build/${BUILD_TYPE}-demo/bin/acord --public
+CMD ["sh", "-c", "./out/build/${BUILD_TYPE}-demo/bin/acord --public"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,35 @@ Or on Windows
 > .\build\bin\acord.exe
 ```
 
+### Building with Docker
+
+If you have Docker installed, you can build acord with the following command:
+
+```bash
+$ docker build -t acord .
+```
+
+This will build the acord image and tag it as `acord`. You can then run it with:
+
+```bash
+$ docker run -it --rm --gpus all -v <local/path/to/models>:/models -p 7654:7654 acord
+```
+
+To make multiplatform build you need to:
+
+- Create a builder instance - run it only once
+
+```bash
+$ docker buildx create --name multiarch-builder --use
+$ docker buildx inspect --bootstrap
+```
+
+- To create the actual image, run the following command:
+
+```bash
+$ docker buildx build --platform linux/arm64,linux/amd64 -t acord .
+```
+
 ## Making Your Own Apps
 
 Feel free to experiment and make your own apps. You can do them in any language you want as long as you have a WebSocket client library.

--- a/server/acord/main.cpp
+++ b/server/acord/main.cpp
@@ -4,14 +4,27 @@
 #include <acord/server/App.hpp>
 #include <ac/jalog/Instance.hpp>
 #include <ac/jalog/sinks/DefaultSink.hpp>
+#include <string.h>
 
 using namespace acord::server;
 
-int main() {
+int main(int argc, char** argv) {
     ac::jalog::Instance jl;
     jl.setup().async().add<ac::jalog::sinks::DefaultSink>();
 
-    App app;
+    acord::server::AppParams params;
+    for (int i = 0; i < argc; i++) {
+        if (strcmp(argv[i], "--port") == 0) {
+            if (i + 1 < argc) {
+                params.wsPort = atoi(argv[i + 1]);
+                i++;
+            }
+        } else if (strcmp(argv[i], "--all") == 0) {
+            params.serveLocalhostOnly = false;
+        }
+    }
+
+    App app(params);
     app.run();
 
     // should never get to here

--- a/server/acord/main.cpp
+++ b/server/acord/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char** argv) {
                 params.wsPort = atoi(argv[i + 1]);
                 i++;
             }
-        } else if (strcmp(argv[i], "--all") == 0) {
+        } else if (strcmp(argv[i], "--public") == 0) {
             params.serveLocalhostOnly = false;
         }
     }

--- a/server/code/acord/server/App.cpp
+++ b/server/code/acord/server/App.cpp
@@ -57,7 +57,9 @@ struct App::Impl {
         }
         else{
             endpoints.push_back({fishnets::IPv4, params.wsPort});
-            endpoints.push_back({fishnets::IPv6, params.wsPort});
+            // TODO: Check why when IPv6 is enabled, the server does not start
+            // when it's started in docker
+            // endpoints.push_back({fishnets::IPv6, params.wsPort});
         }
 
         wsCtx.wsServe(endpoints, std::make_shared<fishnets::SimpleServerHandler>([this](const fishnets::EndpointInfo&, const fishnets::EndpointInfo&) {

--- a/server/code/acord/server/App.hpp
+++ b/server/code/acord/server/App.hpp
@@ -13,8 +13,6 @@ struct AppParams {
 };
 class ACORD_SERVER_API App {
 public:
-
-
     App(AppParams params = {});
     ~App();
 


### PR DESCRIPTION
We use Nvidia's docker image for ubuntu with CUDA drivers, so we don't have to install the packages on our side. I checked that in both x86_64 and arm64 it's correctly built with CUDA support.

Build for native arch
```
docker build  -t <target_name> .
```

To build for specific architecture - x86_64 for example:
```
docker build --platform=linux/amd64  -t <target_name> .
```
To run the image:
```
docker run --gpus all -v <local/path/to/models>:/models -it -p 7654:7654 <target_name>
```

Built image for now can be downloaded from [my docker hub](https://hub.docker.com/r/pacominev/acord).

I've noticed that to make it usable we should complete the following tasks:
- [x] Download models in the accord
   - Since acord îs not yet ready to download, users should download them before usage and mount the local directory to the docker container in order to access them.
- [x] Create a shared volume in the docker, so we can download or move the models there
   - This is the directory mount `-v <local/path>:/<container/path>`
- [x] Make the image smaller by leaving only the Cuda runtime in the final image, do not include dev
- [x] Make single image for amd64 and arm64 architectures - this should be only a command line but still do not forget 

closes #32 